### PR TITLE
ROS-melodic .debs for network_monitor_udp incomplete

### DIFF
--- a/network_monitor_udp/CMakeLists.txt
+++ b/network_monitor_udp/CMakeLists.txt
@@ -6,6 +6,9 @@ project(network_monitor_udp)
 # TODO: remove all from COMPONENTS that are not catkin packages.
 find_package(catkin REQUIRED COMPONENTS roscpp rospy diagnostic_msgs actionlib_msgs actionlib message_generation)
 
+# include python modules
+catkin_python_setup()
+
 # include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 # CATKIN_MIGRATION: removed during catkin migration
 # cmake_minimum_required(VERSION 2.4.6)
@@ -60,3 +63,13 @@ target_link_libraries(udpmonserv ${catkin_LIBRARIES})
 target_link_libraries(udpmonsink ${catkin_LIBRARIES})
 add_dependencies(udpmonsink ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 add_dependencies(udpmonserv ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+install(TARGETS udpmonserv udpmonsink
+    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+catkin_install_python(PROGRAMS nodes/network_watchdog.py nodes/sample_bwtest.py nodes/udpmonclinode.py nodes/udpmonsourcenode.py
+    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+install(FILES launch_nodes.launch
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+)

--- a/network_monitor_udp/CMakeLists.txt
+++ b/network_monitor_udp/CMakeLists.txt
@@ -71,5 +71,5 @@ catkin_install_python(PROGRAMS nodes/network_watchdog.py nodes/sample_bwtest.py 
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 install(FILES launch_nodes.launch
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/network_monitor_udp/nodes/udpmonsourcenode.py
+++ b/network_monitor_udp/nodes/udpmonsourcenode.py
@@ -7,7 +7,7 @@ from math import floor
 
 import roslib; roslib.load_manifest('network_monitor_udp')
 import rospy
-from roslib import rostime
+from rospy import rostime
 
 import actionlib
 import sys

--- a/network_monitor_udp/setup.py
+++ b/network_monitor_udp/setup.py
@@ -1,0 +1,11 @@
+## ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# fetch values from package.xml
+setup_args = generate_distutils_setup(
+    packages=['network_monitor_udp'],
+    package_dir={'': 'src'})
+
+setup(**setup_args)

--- a/network_monitor_udp/src/network_monitor_udp/linktest.py
+++ b/network_monitor_udp/src/network_monitor_udp/linktest.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 import roslib; roslib.load_manifest('network_monitor_udp')
-from roslib import rostime
+from rospy import rostime
 import rospy
 import actionlib
 import network_monitor_udp.msg as msgs


### PR DESCRIPTION
The ROS melodic install of this package is missing most of the useful files, including the node python scripts, python libraries, and standalone binaries.  Additionally, changes to the core ROS python libraries over time meant that some of the python code wouldn't run.

This PR makes the following changes, which (on my test system at least) results in usable python scripts, and generates `.deb` packages that include all the desired output files:
- add setup.py and `catkin_python_setup` to get python libraries included in the .deb
- add `catkin_install_python` to include python node scripts in the .deb
- python package `roslib` is deprecated; `rostime` now lives in `rospy`
- add additional cmake rules so that compiled binaries and .launch file are included in the .deb