### PR TITLE
build/testing fixes for noetic compatibility

### DIFF
--- a/multi_interface_roam/CMakeLists.txt
+++ b/multi_interface_roam/CMakeLists.txt
@@ -5,7 +5,6 @@ project(multi_interface_roam)
 # Load catkin and all dependencies required for this package
 # TODO: remove all from COMPONENTS that are not catkin packages.
 find_package(catkin REQUIRED COMPONENTS rospy network_monitor_udp std_msgs diagnostic_msgs pr2_msgs dynamic_reconfigure ieee80211_channels)
-
 # include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 # CATKIN_MIGRATION: removed during catkin migration
 # cmake_minimum_required(VERSION 2.4.6)

--- a/multi_interface_roam/package.xml
+++ b/multi_interface_roam/package.xml
@@ -25,6 +25,7 @@
   <build_depend>asmach</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>ieee80211_channels</build_depend>
+  <build_depend>python-twisted-core</build_depend>
 
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>rospy</run_depend>

--- a/multi_interface_roam/package.xml
+++ b/multi_interface_roam/package.xml
@@ -48,5 +48,6 @@
   <!-- <test_depend>asmach</test_depend> -->
   <!-- <test_depend>dynamic_reconfigure</test_depend> -->
   <!-- <test_depend>ieee80211_channels</test_depend> -->
+  <test_depend>python-twisted-core</test_depend>
 
 </package>

--- a/multi_interface_roam/package.xml
+++ b/multi_interface_roam/package.xml
@@ -25,7 +25,7 @@
   <build_depend>asmach</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>ieee80211_channels</build_depend>
-  <!--<build_depend>python-twisted-core</build_depend>-->
+  <build_depend>python3-twisted</build_depend>
 
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>rospy</run_depend>
@@ -36,7 +36,7 @@
   <run_depend>asmach</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>ieee80211_channels</run_depend>
-  <!--<run_depend>python-twisted-core</run_depend>-->
+  <run_depend>python3-twisted</run_depend>
 
   <!-- Dependencies needed only for running tests. -->
   <!-- <test_depend>rospy</test_depend> -->
@@ -48,6 +48,5 @@
   <!-- <test_depend>asmach</test_depend> -->
   <!-- <test_depend>dynamic_reconfigure</test_depend> -->
   <!-- <test_depend>ieee80211_channels</test_depend> -->
-  <test_depend>python-twisted-core</test_depend>
 
 </package>

--- a/multi_interface_roam/package.xml
+++ b/multi_interface_roam/package.xml
@@ -25,7 +25,8 @@
   <build_depend>asmach</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>ieee80211_channels</build_depend>
-  <build_depend>python3-twisted</build_depend>
+  <build_depend condition="$ROS_PYTHON_VERSION == 2">python-twisted-core</run_depend>
+  <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-twisted</run_depend> 
 
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>rospy</run_depend>

--- a/multi_interface_roam/package.xml
+++ b/multi_interface_roam/package.xml
@@ -25,7 +25,7 @@
   <build_depend>asmach</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>ieee80211_channels</build_depend>
-  <build_depend>python-twisted-core</build_depend>
+  <!--<build_depend>python-twisted-core</build_depend>-->
 
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>rospy</run_depend>
@@ -36,7 +36,7 @@
   <run_depend>asmach</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>ieee80211_channels</run_depend>
-  <run_depend>python-twisted-core</run_depend>
+  <!--<run_depend>python-twisted-core</run_depend>-->
 
   <!-- Dependencies needed only for running tests. -->
   <!-- <test_depend>rospy</test_depend> -->

--- a/multi_interface_roam/package.xml
+++ b/multi_interface_roam/package.xml
@@ -36,7 +36,8 @@
   <run_depend>asmach</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>ieee80211_channels</run_depend>
-  <run_depend>python3-twisted</run_depend>
+  <run_depend condition="$ROS_PYTHON_VERSION == 2">python-twisted-core</run_depend>
+  <run_depend condition="$ROS_PYTHON_VERSION == 3">python3-twisted</run_depend> 
 
   <!-- Dependencies needed only for running tests. -->
   <!-- <test_depend>rospy</test_depend> -->

--- a/multi_interface_roam/src/multi_interface_roam/async_helpers.py
+++ b/multi_interface_roam/src/multi_interface_roam/async_helpers.py
@@ -3,10 +3,10 @@ from twisted.internet.defer import Deferred, DeferredQueue, inlineCallbacks, ret
 from twisted.internet import reactor
 from twisted.internet.protocol import Protocol
 from collections import deque
-from weakcallback import WeakCallbackCb
+from multi_interface_roam.weakcallback import WeakCallbackCb
 import weakref
 import sys
-from event import Unsubscribe, Event
+from multi_interface_roam.event import Unsubscribe, Event
 
 # FIXME Add test for ReadDescrEventStream
 
@@ -227,7 +227,7 @@ def unittest_with_reactor(run_ros_tests):
                 import unittest
                 unittest.main()
             exitval.append(0)
-        except SystemExit, v:
+        except SystemExit as v:
             exitval.append(v.code)
         except:
             import traceback

--- a/multi_interface_roam/src/multi_interface_roam/command_with_output.py
+++ b/multi_interface_roam/src/multi_interface_roam/command_with_output.py
@@ -80,7 +80,7 @@ class CommandWithOutput(protocol.ProcessProtocol):
         self.logger.info(line)
         try:
             self.got_line(line)
-        except Exception, e:
+        except Exception as e:
             self.console_logger.fatal("Caught exception in CommandWithOutput.run: %s"%str(e))
             raise # FIXME Remove this?
 

--- a/multi_interface_roam/src/multi_interface_roam/event.py
+++ b/multi_interface_roam/src/multi_interface_roam/event.py
@@ -2,7 +2,7 @@
 
 from __future__ import with_statement
 
-import thread
+import _thread
 import weakref
 
 # TODO:

--- a/multi_interface_roam/src/multi_interface_roam/event.py
+++ b/multi_interface_roam/src/multi_interface_roam/event.py
@@ -2,7 +2,6 @@
 
 from __future__ import with_statement
 
-import _thread
 import weakref
 
 # TODO:

--- a/multi_interface_roam/src/multi_interface_roam/mac_addr.py
+++ b/multi_interface_roam/src/multi_interface_roam/mac_addr.py
@@ -58,8 +58,8 @@ def make_special():
             "9" : "A-WEP",
             "A" : "A-WPA2",
             }
-    for mac, descr in base_macs.iteritems():
-        for var, vdescr in variants.iteritems():
+    for mac, descr in base_macs.items():
+        for var, vdescr in variants.items():
             out[mac+var] = descr + " " + vdescr
     return out
 

--- a/multi_interface_roam/src/multi_interface_roam/multi_interface_roam.py
+++ b/multi_interface_roam/src/multi_interface_roam/multi_interface_roam.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#! /usr/bin/env python
 
 # TODO To cleanup: 
 # - Mark on ping packets in not being used.

--- a/multi_interface_roam/src/multi_interface_roam/multi_interface_roam.py
+++ b/multi_interface_roam/src/multi_interface_roam/multi_interface_roam.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 # TODO To cleanup: 
 # - Mark on ping packets in not being used.

--- a/multi_interface_roam/src/multi_interface_roam/state_publisher.py
+++ b/multi_interface_roam/src/multi_interface_roam/state_publisher.py
@@ -2,7 +2,7 @@
 
 from __future__ import with_statement
 
-import event
+import multi_interface_roam.event
 import copy
 
 # TODO

--- a/multi_interface_roam/src/multi_interface_roam/system.py
+++ b/multi_interface_roam/src/multi_interface_roam/system.py
@@ -6,7 +6,7 @@ import os
 from twisted.internet import protocol, reactor
 from twisted.internet.defer import Deferred, inlineCallbacks
 import sys
-import command_with_output # There is a SIGCHLD hack in there that we want to run
+import multi_interface_roam.command_with_output # There is a SIGCHLD hack in there that we want to run
 
 class Quiet:
     pass
@@ -63,7 +63,7 @@ class System(protocol.ProcessProtocol):
         d = Deferred()
         self.shutdown_deferreds.append(d)
         if self.proc:
-            print "Killing command:", self.args
+            print ("Killing command:", self.args)
             self.proc.signalProcess("INT")
         else:
             d.callback()
@@ -73,12 +73,12 @@ def system(*args):
     debug = False
     if debug:
         import time
-        print time.time(), "system: ", args
+        print (time.time(), "system: ", args)
     #print "system: ", args
     s = System(*args)
     if debug:
         def printout(value):
-            print time.time(), "system done: ", args
+            print (time.time(), "system done: ", args)
             return value
         s.deferred.addCallback(printout)
     return s.deferred


### PR DESCRIPTION
updated python scripts and build dependencies to allow for building under noetic (and melodic) using python3.

passing prerelease test:

generate_prerelease_script.py   https://raw.githubusercontent.com/ros-infrastructure/ros_buildfarm_config/production/index.yaml   noetic default ubuntu focal amd64   --custom-repo     linux_networking__custom-2:git:https://github.com/PR2-prime/linux_networking.git:melodic-devel   --level 0   --output-dir ./
