### PR TITLE
Revert "build/testing fixes for noetic compatibility"

### DIFF
--- a/multi_interface_roam/CMakeLists.txt
+++ b/multi_interface_roam/CMakeLists.txt
@@ -5,6 +5,7 @@ project(multi_interface_roam)
 # Load catkin and all dependencies required for this package
 # TODO: remove all from COMPONENTS that are not catkin packages.
 find_package(catkin REQUIRED COMPONENTS rospy network_monitor_udp std_msgs diagnostic_msgs pr2_msgs dynamic_reconfigure ieee80211_channels)
+
 # include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 # CATKIN_MIGRATION: removed during catkin migration
 # cmake_minimum_required(VERSION 2.4.6)

--- a/multi_interface_roam/package.xml
+++ b/multi_interface_roam/package.xml
@@ -25,8 +25,6 @@
   <build_depend>asmach</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>ieee80211_channels</build_depend>
-  <build_depend condition="$ROS_PYTHON_VERSION == 2">python-twisted-core</run_depend>
-  <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-twisted</run_depend> 
 
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>rospy</run_depend>
@@ -37,8 +35,7 @@
   <run_depend>asmach</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>ieee80211_channels</run_depend>
-  <run_depend condition="$ROS_PYTHON_VERSION == 2">python-twisted-core</run_depend>
-  <run_depend condition="$ROS_PYTHON_VERSION == 3">python3-twisted</run_depend> 
+  <run_depend>python-twisted-core</run_depend>
 
   <!-- Dependencies needed only for running tests. -->
   <!-- <test_depend>rospy</test_depend> -->

--- a/multi_interface_roam/src/multi_interface_roam/async_helpers.py
+++ b/multi_interface_roam/src/multi_interface_roam/async_helpers.py
@@ -3,10 +3,10 @@ from twisted.internet.defer import Deferred, DeferredQueue, inlineCallbacks, ret
 from twisted.internet import reactor
 from twisted.internet.protocol import Protocol
 from collections import deque
-from multi_interface_roam.weakcallback import WeakCallbackCb
+from weakcallback import WeakCallbackCb
 import weakref
 import sys
-from multi_interface_roam.event import Unsubscribe, Event
+from event import Unsubscribe, Event
 
 # FIXME Add test for ReadDescrEventStream
 
@@ -227,7 +227,7 @@ def unittest_with_reactor(run_ros_tests):
                 import unittest
                 unittest.main()
             exitval.append(0)
-        except SystemExit as v:
+        except SystemExit, v:
             exitval.append(v.code)
         except:
             import traceback

--- a/multi_interface_roam/src/multi_interface_roam/command_with_output.py
+++ b/multi_interface_roam/src/multi_interface_roam/command_with_output.py
@@ -80,7 +80,7 @@ class CommandWithOutput(protocol.ProcessProtocol):
         self.logger.info(line)
         try:
             self.got_line(line)
-        except Exception as e:
+        except Exception, e:
             self.console_logger.fatal("Caught exception in CommandWithOutput.run: %s"%str(e))
             raise # FIXME Remove this?
 

--- a/multi_interface_roam/src/multi_interface_roam/event.py
+++ b/multi_interface_roam/src/multi_interface_roam/event.py
@@ -2,6 +2,7 @@
 
 from __future__ import with_statement
 
+import thread
 import weakref
 
 # TODO:

--- a/multi_interface_roam/src/multi_interface_roam/mac_addr.py
+++ b/multi_interface_roam/src/multi_interface_roam/mac_addr.py
@@ -58,8 +58,8 @@ def make_special():
             "9" : "A-WEP",
             "A" : "A-WPA2",
             }
-    for mac, descr in base_macs.items():
-        for var, vdescr in variants.items():
+    for mac, descr in base_macs.iteritems():
+        for var, vdescr in variants.iteritems():
             out[mac+var] = descr + " " + vdescr
     return out
 

--- a/multi_interface_roam/src/multi_interface_roam/state_publisher.py
+++ b/multi_interface_roam/src/multi_interface_roam/state_publisher.py
@@ -2,7 +2,7 @@
 
 from __future__ import with_statement
 
-import multi_interface_roam.event
+import event
 import copy
 
 # TODO

--- a/multi_interface_roam/src/multi_interface_roam/system.py
+++ b/multi_interface_roam/src/multi_interface_roam/system.py
@@ -6,7 +6,7 @@ import os
 from twisted.internet import protocol, reactor
 from twisted.internet.defer import Deferred, inlineCallbacks
 import sys
-import multi_interface_roam.command_with_output # There is a SIGCHLD hack in there that we want to run
+import command_with_output # There is a SIGCHLD hack in there that we want to run
 
 class Quiet:
     pass
@@ -63,7 +63,7 @@ class System(protocol.ProcessProtocol):
         d = Deferred()
         self.shutdown_deferreds.append(d)
         if self.proc:
-            print ("Killing command:", self.args)
+            print "Killing command:", self.args
             self.proc.signalProcess("INT")
         else:
             d.callback()
@@ -73,12 +73,12 @@ def system(*args):
     debug = False
     if debug:
         import time
-        print (time.time(), "system: ", args)
+        print time.time(), "system: ", args
     #print "system: ", args
     s = System(*args)
     if debug:
         def printout(value):
-            print (time.time(), "system done: ", args)
+            print time.time(), "system done: ", args
             return value
         s.deferred.addCallback(printout)
     return s.deferred


### PR DESCRIPTION
Reverts PR2/linux_networking#5

failing on noetic build

```
Traceback (most recent call last):
  File "/usr/bin/catkin", line 11, in <module>
    load_entry_point('catkin-tools==0.5.0', 'console_scripts', 'catkin')()
  File "/usr/lib/python3/dist-packages/catkin_tools/commands/catkin.py", line 272, in main
    catkin_main(sysargs)
  File "/usr/lib/python3/dist-packages/catkin_tools/commands/catkin.py", line 267, in catkin_main
    sys.exit(args.main(args) or 0)
  File "/usr/lib/python3/dist-packages/catkin_tools/verbs/catkin_build/cli.py", line 404, in main
    return build_isolated_workspace(
  File "/usr/lib/python3/dist-packages/catkin_tools/verbs/catkin_build/build.py", line 296, in build_isolated_workspace
    workspace_packages = find_packages(context.source_space_abs, exclude_subspaces=True, warnings=[])
  File "/usr/lib/python3/dist-packages/catkin_pkg/packages.py", line 87, in find_packages
    packages = find_packages_allowing_duplicates(basepath, exclude_paths=exclude_paths, exclude_subspaces=exclude_subspaces, warnings=warnings)
  File "/usr/lib/python3/dist-packages/catkin_pkg/packages.py", line 147, in find_packages_allowing_duplicates
    parsed_package = parse_package_string(
  File "/usr/lib/python3/dist-packages/catkin_pkg/package.py", line 598, in parse_package_string
    raise InvalidPackage('The manifest contains invalid XML:\n%s' % ex, filename)
catkin_pkg.package.InvalidPackage: Error(s) in package '/home/user/ws_pr2/src/linux_networking/multi_interface_roam/package.xml':
The manifest contains invalid XML:
```